### PR TITLE
Update da.lua

### DIFF
--- a/locales/da.lua
+++ b/locales/da.lua
@@ -191,6 +191,8 @@ local Translations = {
         ["entity_view_vehicles_desc"] = "Aktiver/deaktiver køretøjsoplysninger i verden",
         ["entity_view_objects_desc"] = "Aktiver/deaktiver objektinfo i verden",
         ["entity_view_freeaim_copy_desc"] = "Kopierer oplysningerne om Free Aim-enheden til udklipsholder",
+        ["spawn_weapons_desc"] = "Giv hvilket som helst våben.", 
+        ["max_mod_desc"] = "Max mod dit nuværende køretøj",
     },
     time = {
         ["ban_length"] = "Udelukkelse Længde",


### PR DESCRIPTION
just wanted to update the locals for the danish language saw that i got `Warning: Missing phrase for key: "desc.max_mod_desc"` with a fresh install of the admin menu with the da config for qbcore and saw that it was missing the part + the translating
